### PR TITLE
feat: preview deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -983,12 +983,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
-    "@types/clipboardy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
-      "integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1012,9 +1006,9 @@
       }
     },
     "@types/got": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.4.1.tgz",
-      "integrity": "sha512-m7Uc07bG/bZ+Dis7yI3mGssYDcAdUvP4irF3ZmBzf0ig7zEd1FyADfnELVGcf+p1Ol/iPCXbZYwcSNOJA2a+Qg==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.4.2.tgz",
+      "integrity": "sha512-k9F2iT5+Ym1jmAGjZyLsd0P3F8XB+4/gntbkx6Lofu7JvRINVIHa+l+fufLqtrJhgUw7UZqTfA+S6McPNXlPug==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1409,71 +1403,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "babel-jest": {
       "version": "24.7.1",
@@ -11797,12 +11726,12 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
-      "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
+      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,8 @@
     "@semantic-release/gitlab": "^3.1.2",
     "@semantic-release/npm": "^5.1.4",
     "@smartive/tslint-config": "^6.0.0",
-    "@types/clipboardy": "^1.1.0",
     "@types/fs-extra": "^5.0.5",
-    "@types/got": "^9.4.1",
+    "@types/got": "^9.4.2",
     "@types/inquirer": "6.0.0",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.13.4",
@@ -75,7 +74,7 @@
     "pkg": "^4.3.7",
     "semantic-release": "^15.13.3",
     "ts-jest": "^24.0.2",
-    "tslint": "^5.15.0",
+    "tslint": "^5.16.0",
     "tsutils": "^3.10.0",
     "typescript": "^3.4.3"
   }

--- a/src/commands/apply/index.ts
+++ b/src/commands/apply/index.ts
@@ -55,6 +55,7 @@ export const applyCommand: CommandModule<RootArguments, ApplyArguments> = {
       await kubeConfigCommand.handler({
         ...args,
         noInteraction: true,
+        force: true,
       });
     }
 

--- a/src/commands/delete/index.ts
+++ b/src/commands/delete/index.ts
@@ -60,6 +60,7 @@ export const deleteCommand: CommandModule<RootArguments, DeleteArguments> = {
       await kubeConfigCommand.handler({
         ...args,
         noInteraction: true,
+        force: true,
       });
     }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ import { kubeConfigCommand } from './kube-config';
 import { kubectlCommand } from './kubectl';
 import { namespaceCommand } from './namespace';
 import { prepareCommand } from './prepare';
+import { previewDeployCommand } from './preview-deploy';
 import { secretCommand } from './secret';
 import { versionCommand } from './version';
 
@@ -22,6 +23,7 @@ export const commands: CommandModule<any, any>[] = [
   kubectlCommand,
   namespaceCommand,
   prepareCommand,
+  previewDeployCommand,
   secretCommand,
   versionCommand,
 ];

--- a/src/commands/preview-deploy/index.ts
+++ b/src/commands/preview-deploy/index.ts
@@ -1,0 +1,221 @@
+import {
+  V1Namespace,
+  V1ObjectMeta,
+  V1PolicyRule,
+  V1Role,
+  V1RoleBinding,
+  V1RoleRef,
+  V1ServiceAccount,
+  V1Subject,
+} from '@kubernetes/client-node';
+import { Arguments, Argv, CommandModule } from 'yargs';
+
+import { RootArguments } from '../../root-arguments';
+import { ExitCode } from '../../utils/exit-code';
+import { KubernetesApi } from '../../utils/kubernetes-api';
+import { Logger } from '../../utils/logger';
+
+type PreviewDeployArguments = RootArguments & {
+  name: string;
+  sourceFolder: string;
+  prefix: string;
+  kubeConfig?: string;
+};
+
+const logger = new Logger('preview deployment');
+
+async function createNamespace(api: KubernetesApi, name: string): Promise<void> {
+  try {
+    logger.info(`Create preview namespace "${name}".`);
+    await api.core.readNamespace(name);
+    logger.info(`Namespace "${name}" already exists.`);
+  } catch (e) {
+    if (e.response.statusCode !== 404) {
+      throw e;
+    }
+
+    await api.core.createNamespace({
+      ...new V1Namespace(),
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        ...new V1ObjectMeta(),
+        name,
+      },
+    });
+    logger.success(`Created namespace "${name}".`);
+  }
+}
+
+async function createServiceAccount(api: KubernetesApi, namespace: string): Promise<void> {
+  const name = 'deploy';
+  try {
+    await api.core.readNamespacedServiceAccount(name, namespace);
+    logger.info('Service account already exists.');
+  } catch (e) {
+    if (e.response.statusCode !== 404) {
+      throw e;
+    }
+
+    await api.core.createNamespacedServiceAccount(namespace, {
+      ...new V1ServiceAccount(),
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        ...new V1ObjectMeta(),
+        name,
+      },
+    });
+    logger.success('Created service account "deploy".');
+  }
+}
+
+async function createRole(api: KubernetesApi, namespace: string): Promise<void> {
+  const name = 'deploy-role';
+  try {
+    await api.rbac.readNamespacedRole(name, namespace);
+    logger.info('Role already exists.');
+  } catch (e) {
+    if (e.response.statusCode !== 404) {
+      throw e;
+    }
+
+    await api.rbac.createNamespacedRole(namespace, {
+      ...new V1Role(),
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        ...new V1ObjectMeta(),
+        name,
+      },
+      rules: [
+        {
+          ...new V1PolicyRule(),
+          verbs: ['*'],
+          apiGroups: [
+            '',
+            'apps',
+            'batch',
+            'certmanager.k8s.io',
+            'extensions',
+            'rbac.authorization.k8s.io',
+          ],
+          resources: [
+            'certificates',
+            'cronjobs',
+            'configmaps',
+            'deployments',
+            'ingresses',
+            'jobs',
+            'persistentvolumeclaims',
+            'pods',
+            'rolebindings',
+            'roles',
+            'secrets',
+            'serviceaccounts',
+            'services',
+          ],
+        },
+      ],
+    });
+    logger.success('Created role "deploy-role".');
+  }
+}
+
+async function createRoleBinding(api: KubernetesApi, namespace: string): Promise<void> {
+  const name = 'deploy-role-binding';
+  try {
+    await api.rbac.readNamespacedRoleBinding(name, namespace);
+    logger.info('RoleBinding already exists.');
+  } catch (e) {
+    if (e.response.statusCode !== 404) {
+      throw e;
+    }
+
+    await api.rbac.createNamespacedRoleBinding(namespace, {
+      ...new V1RoleBinding(),
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        ...new V1ObjectMeta(),
+        name,
+      },
+      roleRef: {
+        ...new V1RoleRef(),
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'deploy-role',
+      },
+      subjects: [
+        {
+          ...new V1Subject(),
+          namespace,
+          kind: 'ServiceAccount',
+          name: 'deploy',
+        },
+      ],
+    });
+    logger.success('Created rolebinding "deploy-role-binding".');
+  }
+}
+
+export const previewDeployCommand: CommandModule<RootArguments, PreviewDeployArguments> = {
+  command: 'preview-deploy <name> [sourceFolder]',
+  aliases: 'prev-dep',
+  describe:
+    'Create opinionated preview deployment. This command creates a namespace, ' +
+    'the rolebindings in there and deploys the application in the given namespace.',
+
+  builder: (argv: Argv<RootArguments>) =>
+    argv
+      .option('prefix', {
+        string: true,
+        description: 'Defines the prefix for the namespace name.',
+        default: 'prev-',
+      })
+      .option('kube-config', {
+        string: true,
+        description: 'Define the kube config to use for namespace creation. Defaults to $KUBE_CONFIG variable.',
+      })
+      .positional('name', {
+        description: 'Name of the preview namespace.',
+        type: 'string',
+      })
+      .positional('sourceFolder', {
+        description: 'Folder to search for yaml files.',
+        type: 'string',
+        default: './k8s/',
+      }) as Argv<PreviewDeployArguments>,
+
+  async handler(args: Arguments<PreviewDeployArguments>): Promise<void> {
+    if (args.getYargsCompletions) {
+      return;
+    }
+
+    logger.debug('Execute preview deployment');
+
+    const name = `${args.prefix}${args.name}`;
+    if (name.length > 64) {
+      logger.error(`Name of the namespace "${name}" is too long (max: 64 characters, is: ${args.name.length})`);
+      process.exit(ExitCode.error);
+      return;
+    }
+
+    const api = args.kubeConfig ?
+      KubernetesApi.fromString(args.kubeConfig.isBase64() ? args.kubeConfig.base64Decode() : args.kubeConfig) :
+      KubernetesApi.fromDefault();
+
+    await createNamespace(api, name);
+    await createServiceAccount(api, name);
+    await createRole(api, name);
+    await createRoleBinding(api, name);
+
+    // await prepareCommand.handler(args);
+    // await applyCommand.handler({
+    //   ...args,
+    //   deployFolder: args.destinationFolder,
+    // });
+
+    logger.success(`Preview Deployment applied to namespace "${name}".`);
+  },
+};

--- a/src/kubernetes-helpers.ts
+++ b/src/kubernetes-helpers.ts
@@ -106,7 +106,7 @@ alias('h', 'help');
 help('help');
 wrap(terminalWidth());
 
-epilog(chalk.dim(`This tool intends to help with everyday kubernetes administration.`));
+epilog(chalk.dim('This tool intends to help with everyday kubernetes administration.'));
 
 const args = parse();
 if (args._.length === 0 && !args.getYargsCompletions) {

--- a/src/utils/kubernetes-api.ts
+++ b/src/utils/kubernetes-api.ts
@@ -1,4 +1,4 @@
-import { Core_v1Api, KubeConfig, RbacAuthorization_v1Api } from '@kubernetes/client-node';
+import { Core_v1Api, KubeConfig } from '@kubernetes/client-node';
 import { Context } from '@kubernetes/client-node/dist/config_types';
 
 export class KubernetesApi {
@@ -10,11 +10,6 @@ export class KubernetesApi {
    * Manage elements of the kubernetes core api.
    */
   public readonly core: Core_v1Api;
-
-  /**
-   * Manage elements of the kubernetes rbac.authorization/v1 api.
-   */
-  public readonly rbac: RbacAuthorization_v1Api;
 
   /**
    * Manage kube-config.
@@ -51,7 +46,6 @@ export class KubernetesApi {
     }
 
     this.core = this.kubeConfig.makeApiClient(Core_v1Api);
-    this.rbac = this.kubeConfig.makeApiClient(RbacAuthorization_v1Api);
   }
 
   /**

--- a/src/utils/kubernetes-api.ts
+++ b/src/utils/kubernetes-api.ts
@@ -1,4 +1,4 @@
-import { Core_v1Api, KubeConfig } from '@kubernetes/client-node';
+import { Core_v1Api, KubeConfig, RbacAuthorization_v1Api } from '@kubernetes/client-node';
 import { Context } from '@kubernetes/client-node/dist/config_types';
 
 export class KubernetesApi {
@@ -7,26 +7,14 @@ export class KubernetesApi {
   public static namespaceOverride: string | undefined;
 
   /**
-   * Manage elements of the kubernetes core api:
-   * - bindings
-   * - componentstatuses
-   * - configmaps
-   * - endpoints
-   * - events
-   * - limitranges
-   * - namespaces
-   * - nodes
-   * - persistentvolumeclaims
-   * - persistentvolumes
-   * - pods
-   * - podtemplates
-   * - replicationcontrollers
-   * - resourcequotas
-   * - secrets
-   * - serviceaccounts
-   * - services
+   * Manage elements of the kubernetes core api.
    */
   public readonly core: Core_v1Api;
+
+  /**
+   * Manage elements of the kubernetes rbac.authorization/v1 api.
+   */
+  public readonly rbac: RbacAuthorization_v1Api;
 
   /**
    * Manage kube-config.
@@ -63,6 +51,7 @@ export class KubernetesApi {
     }
 
     this.core = this.kubeConfig.makeApiClient(Core_v1Api);
+    this.rbac = this.kubeConfig.makeApiClient(RbacAuthorization_v1Api);
   }
 
   /**
@@ -73,6 +62,15 @@ export class KubernetesApi {
   public static fromDefault(): KubernetesApi {
     const kubeConfig = new KubeConfig();
     kubeConfig.loadFromDefault();
+    return new KubernetesApi(kubeConfig);
+  }
+
+  /**
+   * Creates the kubernetes api from a given string content.
+   */
+  public static fromString(content: string): KubernetesApi {
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromString(content);
     return new KubernetesApi(kubeConfig);
   }
 }

--- a/test/commands/preview-deploy/__snapshots__/preview-deploy.spec.ts.snap
+++ b/test/commands/preview-deploy/__snapshots__/preview-deploy.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`commands / preview-deploy should create a namespace with the given name 1`] = `
+Object {
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": Object {
+    "name": "prev-foobar",
+  },
+}
+`;

--- a/test/commands/preview-deploy/preview-deploy.spec.ts
+++ b/test/commands/preview-deploy/preview-deploy.spec.ts
@@ -1,0 +1,109 @@
+import { vol } from 'memfs';
+
+import { previewDeployCommand } from '../../../src/commands/preview-deploy';
+import { exec } from '../../../src/utils/exec';
+import { KubernetesApi } from '../../../src/utils/kubernetes-api';
+import { Logger } from '../../../src/utils/logger';
+import { clearGlobalMocks } from '../../helpers';
+
+function defaultFiles(): void {
+  vol.fromJSON({
+    '/foo.yml': 'foo:\n  bar: yaml',
+    '/bar.yml': 'bar:\n  foo: yaml',
+  });
+}
+
+describe('commands / preview-deploy', () => {
+  beforeAll(() => {
+    process.exit = jest.fn() as any;
+  });
+
+  beforeEach(() => {
+    (KubernetesApi as any).create();
+  });
+
+  afterEach(() => {
+    clearGlobalMocks();
+  });
+
+  it('should exit when the name is too long', async () => {
+    await previewDeployCommand.handler({
+      name: '1234567890123456789012345678901234567890123456789012345678901234567890',
+    } as any);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect((Logger as any).instance.error.mock.calls[0][0]).toContain('Name of the namespace');
+  });
+
+  it('should use the default kube config when no flag is set', async () => {
+    defaultFiles();
+    const spy = jest.spyOn(KubernetesApi, 'fromDefault');
+    await previewDeployCommand.handler({
+      name: 'foobar',
+      prefix: 'prev-',
+      sourceFolder: '/',
+    } as any);
+
+    try {
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('should use the given kube config content when the flag is set', async () => {
+    defaultFiles();
+    const spy = jest.spyOn(KubernetesApi, 'fromString');
+    await previewDeployCommand.handler({
+      name: 'foobar',
+      prefix: 'prev-',
+      sourceFolder: '/',
+      kubeConfig: 'yeeeehaaaw',
+    } as any);
+
+    try {
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('should create a namespace with the given name', async () => {
+    defaultFiles();
+    (KubernetesApi as any).instance.core.readNamespace.mockRejectedValueOnce({
+      response: {
+        statusCode: 404,
+      },
+    });
+
+    await previewDeployCommand.handler({
+      name: 'foobar',
+      prefix: 'prev-',
+      sourceFolder: '/',
+    } as any);
+
+    expect((KubernetesApi as any).instance.core.createNamespace.mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  it('should not create the namespace when it already exists', async () => {
+    defaultFiles();
+    await previewDeployCommand.handler({
+      name: 'foobar',
+      prefix: 'prev-',
+      sourceFolder: '/',
+    } as any);
+
+    expect((KubernetesApi as any).instance.core.createNamespace).not.toHaveBeenCalled();
+  });
+
+  it('should execute kubectl with the found yamls', async () => {
+    defaultFiles();
+
+    await previewDeployCommand.handler({
+      name: 'foobar',
+      prefix: 'prev-',
+      sourceFolder: '/',
+    } as any);
+
+    expect(exec).toHaveBeenCalled();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,12 +1,12 @@
-import 'clipboardy';
-import 'inquirer';
-
-import { Core_v1Api, V1Secret } from '@kubernetes/client-node';
 import '../src/utils/exec';
 import '../src/utils/extensions';
 import '../src/utils/kubernetes-api';
 import '../src/utils/logger';
 import '../src/utils/spawn';
+import 'clipboardy';
+import 'inquirer';
+
+import { Core_v1Api, V1Namespace, V1Secret } from '@kubernetes/client-node';
 
 jest.mock('fs');
 jest.mock('../src/utils/spawn', () => ({
@@ -56,15 +56,21 @@ jest.mock('../src/utils/kubernetes-api', () => ({
 
     public core: Core_v1Api = ({
       createNamespacedSecret: jest.fn().mockImplementation(async (_ns: string, secret: V1Secret) => ({ body: secret })),
+      readNamespace: jest.fn().mockResolvedValue({}),
+      createNamespace: jest.fn().mockImplementation(async (_ns: string, namespace: V1Namespace) => ({ body: namespace })),
     } as unknown) as Core_v1Api;
 
-    private constructor() {}
+    private constructor() { }
 
     public static create(): void {
       FakeKubernetesApi.instance = new FakeKubernetesApi();
     }
 
     public static fromDefault(): FakeKubernetesApi {
+      return FakeKubernetesApi.instance;
+    }
+
+    public static fromString(): FakeKubernetesApi {
       return FakeKubernetesApi.instance;
     }
   },


### PR DESCRIPTION
This new command adds the possibility to perform the following steps:
1. create a new namespace (should be a deterministic name)
2. create a deployment (via "dep") in that new namespace

after your preview branch is closed, you can delete the whole branch instead of relying on files in git.